### PR TITLE
build: explicit restart policy for containers

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,4 @@ COMPOSE_FILE=docker-compose.yml;docker-compose-run.yml
 COMPOSE_PROJECT_NAME=off_shared
 MONGODB_CACHE_SIZE=8 # GB
 COMMON_NET_NAME=off_shared_network
+RESTART_POLICY=no

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -83,6 +83,8 @@ jobs:
           echo "DOCKER_CLIENT_TIMEOUT=360" >> .env
           echo "COMPOSE_HTTP_TIMEOUT=360" >> .env
 
+          echo "RESTART_POLICY=always" >> .env
+
           # Use old po project name for now so we don't disrupt the current deployment
           echo "COMPOSE_PROJECT_NAME=po" >> .env
           echo "COMMON_NET_NAME=${{ env.COMMON_NET_NAME }}" >> .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,10 @@
 services:
   redis:
     image: redis:7.2-alpine
+    restart: ${RESTART_POLICY:-always}
     command: redis-server --save 60 1 --loglevel warning
 
   mongodb:
     image: mongo:4.4
+    restart: ${RESTART_POLICY:-always}
     command: mongod --wiredTigerCacheSizeGB ${MONGODB_CACHE_SIZE}


### PR DESCRIPTION
It's cumbersome for developers to have containers automatically starting
