### PR TITLE
Only prune docker resources created by this project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ livecheck:
 
 prune:
 	@echo "🥫 Pruning unused Docker artifacts (save space) …"
-	docker system prune -af
+	docker system prune -af --filter="label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}"
 
 create_external_networks:
 	docker network create ${COMMON_NET_NAME} || true


### PR DESCRIPTION
### What
`make prune` is too aggressive. it's removing resources that were created outside of this project.

### Part of 
https://github.com/openfoodfacts/openfoodfacts-server/pull/11502