### PR TITLE
feat: Add shared PostgreSQL service

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,17 @@ COMPOSE_PROJECT_NAME=off_shared
 MONGODB_CACHE_SIZE=8 # GB
 COMMON_NET_NAME=off_shared_network
 RESTART_POLICY=no
+
+# PostgreSQL Settings
+POSTGRES_IMAGE=pgautoupgrade/pgautoupgrade:16-alpine
+POSTGRES_SHM_SIZE=256m
+# This is the default. Use 16G in production
+POSTGRES_SHARED_BUFFERS=128MB
+# This is the default. Use 1G in production
+POSTGRES_WORK_MEM=4MB
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=SuperSecret123!
+
+# The "bootstrap" user has minimal permissions to create other users, so is less secret
+PG_BOOTSTRAP_USERNAME=bootstrap
+PG_BOOTSTRAP_PASSWORD=off

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -97,6 +97,17 @@ jobs:
           echo "MONGODB_HOST=${{ env.MONGODB_HOST }}" >> .env
           echo "MONGODB_EXPOSE=27017" >> .env
 
+          echo "POSTGRES_IMAGE=pgautoupgrade/pgautoupgrade:16-alpine >> .env
+          echo "POSTGRES_USER=postgres >> .env
+          echo "POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }} >> .env
+          echo "PG_BOOTSTRAP_USERNAME=bootstrap >> .env
+          echo "PG_BOOTSTRAP_PASSWORD=${{ secrets.PG_BOOTSTRAP_PASSWORD }} >> .env
+
+          # May want to make these environment specific if we were to deploy to production
+          echo "POSTGRES_SHM_SIZE=256m" >> .env
+          echo "POSTGRES_SHARED_BUFFERS=128MB >> .env
+          echo "POSTGRES_WORK_MEM=4MB >> .env
+
     - name: Create Docker volumes and networks
       uses: appleboy/ssh-action@master
       with:

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -49,7 +49,6 @@ jobs:
         proxy_host: ${{ env.SSH_PROXY_HOST }}
         proxy_username: ${{ env.SSH_USERNAME }}
         proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
-        script_stop: false
         script: |
           # Clone Git repository if not already there
           [ ! -d '${{ matrix.env }}' ] && git clone --depth 1 https://github.com/${{ github.repository }} ${{ matrix.env }} --no-single-branch 2>&1
@@ -72,7 +71,6 @@ jobs:
         proxy_host: ${{ env.SSH_PROXY_HOST }}
         proxy_username: ${{ env.SSH_USERNAME }}
         proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
-        script_stop: false
         script: |
           # Go to repository directory
           cd ${{ matrix.env }}
@@ -90,7 +88,7 @@ jobs:
           echo "COMMON_NET_NAME=${{ env.COMMON_NET_NAME }}" >> .env
 
           echo "COMPOSE_PATH_SEPARATOR=;" >> .env
-          echo "COMPOSE_FILE=docker-compose.yml;docker/prod.yml" >> .env
+          echo "COMPOSE_FILE=docker-compose.yml;docker/${{ matrix.env }}.yml" >> .env
 
           # Use dbdata docker volume for now to keep consistency with previous po owned deployment
           echo "MONGODB_DATA_VOLUME=dbdata" >> .env
@@ -108,13 +106,14 @@ jobs:
         proxy_host: ${{ env.SSH_PROXY_HOST }}
         proxy_username: ${{ env.SSH_USERNAME }}
         proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
-        script_stop: false
         # Note again hard-coded po prefixes are used for now
         script: |
           docker volume create dbdata \
           || echo "dbdata volume already exists"
           docker volume create --driver=local -o type=none -o o=bind -o device=/srv/off/docker_data/redis po_redisdata \
           || echo "redisdata volume already exists"
+          docker volume create --driver=local -o type=none -o o=bind -o device=/srv/off/docker_data/off_shared_pg_data off_shared_pg_data \
+          || echo "off_shared_pg_data volume already exists"
 
     - name: Start services
       uses: appleboy/ssh-action@master
@@ -126,7 +125,6 @@ jobs:
         proxy_username: ${{ env.SSH_USERNAME }}
         proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
         command_timeout: 15m
-        script_stop: false
         script: |
           cd ${{ matrix.env }}
           make run
@@ -141,7 +139,6 @@ jobs:
         proxy_host: ${{ env.SSH_PROXY_HOST }}
         proxy_username: ${{ env.SSH_USERNAME }}
         proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
-        script_stop: false
         script: |
           cd ${{ matrix.env }} && \
           make livecheck
@@ -156,7 +153,6 @@ jobs:
         proxy_host: ${{ env.SSH_PROXY_HOST }}
         proxy_username: ${{ env.SSH_USERNAME }}
         proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
-        script_stop: false
         script: |
           cd ${{ matrix.env }} && \
           make prune

--- a/Makefile
+++ b/Makefile
@@ -43,27 +43,26 @@ create_external_networks:
 	docker network create ${COMMON_NET_NAME} || true
 
 # The escaping for this is complicated as psql needs newlines in the SQL and printf seems to be the only way to get them.
-# Need to double escape the backslashes in printf for the psql meta commands (like "\if").
-# Also need an extra backslash before any "e"s for some reason.
+# Need to quadruple escape the backslashes for the psql meta commands (like "\if") as bash interprets them first and then printf second.
 # Need -T on docker exec to disable the automatic TTY allocation. Otherwise get "the input device is not a TTY"
 create_bootstrap:
-	@printf "SELECT NOT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = '${PG_BOOTSTRAP_USERNAME}') AS bootstrap_needed \\gset \n\
-	\\if :bootstrap_needed \n\
+	@printf "SELECT NOT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = '${PG_BOOTSTRAP_USERNAME}') AS bootstrap_needed \\\\gset \n\
+	\\\\if :bootstrap_needed \n\
  		create role ${PG_BOOTSTRAP_USERNAME} with password '${PG_BOOTSTRAP_PASSWORD}' login createdb createrole; \n\
- 	\\\endif \n" | docker compose exec -T -e PGUSER=${POSTGRES_USER} postgres psql
+ 	\\\\endif \n" | docker compose exec -T -e PGUSER=${POSTGRES_USER} postgresql psql
 
 # Creates a user and database for a service. Database name is the same as the username
 # Usage (typically called from another Makefile):
 # cd ${DEPS_DIR}/openfoodfacts-shared-services && $(MAKE) create_user username=${MY_SERVICE_USERNAME} password=${MY_SERVICE_PASSWORD}
 create_user: create_bootstrap
 # Connect as the bootstrap user to create the service user
-	@printf "SELECT NOT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = '${username}') AS user_needed \\gset \n\
-	\\if :user_needed \n\
+	@printf "SELECT NOT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = '${username}') AS user_needed \\\\gset \n\
+	\\\\if :user_needed \n\
  		create role ${username} with password '${password}' login createdb; \n\
- 	\\\endif \n" | docker compose exec -T -e PGUSER=${PG_BOOTSTRAP_USERNAME} -e PGDATABASE=${POSTGRES_USER} postgres psql
+ 	\\\\endif \n" | docker compose exec -T -e PGUSER=${PG_BOOTSTRAP_USERNAME} -e PGDATABASE=${POSTGRES_USER} postgresql psql
 
 # Then connect as the service user to create the service database
-	@printf "SELECT NOT EXISTS(SELECT FROM pg_database WHERE datname = '${username}') AS db_needed \\gset \n\
-	\\if :db_needed \n\
+	@printf "SELECT NOT EXISTS(SELECT FROM pg_database WHERE datname = '${username}') AS db_needed \\\\gset \n\
+	\\\\if :db_needed \n\
  		create database ${username}; \n\
- 	\\\endif \n" | docker compose exec -T -e PGUSER=${username} -e PGDATABASE=${POSTGRES_USER} postgres psql
+ 	\\\\endif \n" | docker compose exec -T -e PGUSER=${username} -e PGDATABASE=${POSTGRES_USER} postgresql psql

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ include .env
 
 export
 
-run: create_external_networks
-# Make sure the import directy is owned by the host, not docker
+run: create_external_network
+# Make sure the import directory is owned by the host, not docker
 	@mkdir -p ./import
-	docker compose up -d
+	docker compose up --wait
 
 import_prod_data: run
 	@echo "🥫 Importing production data (~2M products) into MongoDB …"
@@ -41,3 +41,29 @@ prune:
 
 create_external_networks:
 	docker network create ${COMMON_NET_NAME} || true
+
+# The escaping for this is complicated as psql needs newlines in the SQL and printf seems to be the only way to get them.
+# Need to double escape the backslashes in printf for the psql meta commands (like "\if").
+# Also need an extra backslash before any "e"s for some reason.
+# Need -T on docker exec to disable the automatic TTY allocation. Otherwise get "the input device is not a TTY"
+create_bootstrap:
+	@printf "SELECT NOT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = '${PG_BOOTSTRAP_USERNAME}') AS bootstrap_needed \\gset \n\
+	\\if :bootstrap_needed \n\
+ 		create role ${PG_BOOTSTRAP_USERNAME} with password '${PG_BOOTSTRAP_PASSWORD}' login createdb createrole; \n\
+ 	\\\endif \n" | docker compose exec -T -e PGUSER=${POSTGRES_USER} postgres psql
+
+# Creates a user and database for a service. Database name is the same as the username
+# Usage (typically called from another Makefile):
+# cd ${DEPS_DIR}/openfoodfacts-shared-services && $(MAKE) create_user username=${MY_SERVICE_USERNAME} password=${MY_SERVICE_PASSWORD}
+create_user: create_bootstrap
+# Connect as the bootstrap user to create the service user
+	@printf "SELECT NOT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = '${username}') AS user_needed \\gset \n\
+	\\if :user_needed \n\
+ 		create role ${username} with password '${password}' login createdb; \n\
+ 	\\\endif \n" | docker compose exec -T -e PGUSER=${PG_BOOTSTRAP_USERNAME} -e PGDATABASE=${POSTGRES_USER} postgres psql
+
+# Then connect as the service user to create the service database
+	@printf "SELECT NOT EXISTS(SELECT FROM pg_database WHERE datname = '${username}') AS db_needed \\gset \n\
+	\\if :db_needed \n\
+ 		create database ${username}; \n\
+ 	\\\endif \n" | docker compose exec -T -e PGUSER=${username} -e PGDATABASE=${POSTGRES_USER} postgres psql

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ include .env
 
 export
 
-run: create_external_network
+run: create_external_networks
 # Make sure the import directory is owned by the host, not docker
 	@mkdir -p ./import
 	docker compose up --wait

--- a/docker-compose-run.yml
+++ b/docker-compose-run.yml
@@ -17,9 +17,18 @@ services:
     networks:
       - common_net
 
+  postgresql:
+    ports:
+      - "${POSTGRES_EXPOSE:-127.0.0.1:5432}:5432"
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    networks:
+      - common_net
+
 volumes:
   dbdata:
   redisdata:
+  pg_data:
   
 networks:
   common_net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,18 @@ services:
     image: mongo:4.4
     restart: ${RESTART_POLICY:-always}
     command: mongod --wiredTigerCacheSizeGB ${MONGODB_CACHE_SIZE}
+
+  postgresql:
+    image: ${POSTGRES_IMAGE}
+    command: postgres -c shared_buffers=${POSTGRES_SHARED_BUFFERS} -c work_mem=${POSTGRES_WORK_MEM} -c listen_addresses='*'
+    restart: ${RESTART_POLICY:-always}
+    environment:
+      - POSTGRES_USER
+      - POSTGRES_PASSWORD
+      - PGAUTO_REINDEX=no
+    shm_size: ${POSTGRES_SHM_SIZE}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      interval: 1s
+      timeout: 5s
+      retries: 25

--- a/docker/shared-net.yml
+++ b/docker/shared-net.yml
@@ -25,6 +25,14 @@ services:
     networks:
       - common_net
 
+  postgresql:
+    ports:
+      - "${POSTGRES_EXPOSE:5432}:5432"
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    networks:
+      - common_net
+
 volumes:
   redisdata:
     external: true
@@ -33,6 +41,10 @@ volumes:
   dbdata:
     external: true
     name: ${MONGODB_DATA_VOLUME}
+
+  pg_data:
+    external: true
+    name: off_shared_pg_data
 
 networks:
   common_net:


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What
- Creates a PostgreSQL instance that can be shared by other services. Each service has its own dedicated user name and database

Part of: https://github.com/openfoodfacts/openfoodfacts-auth/issues/221
