### PR TITLE
fix: Don't include PostgreSQL in the docker-compose file refrenced by PO intergration tests

### DIFF
--- a/docker-compose-run.yml
+++ b/docker-compose-run.yml
@@ -18,6 +18,19 @@ services:
       - common_net
 
   postgresql:
+    image: ${POSTGRES_IMAGE}
+    command: postgres -c shared_buffers=${POSTGRES_SHARED_BUFFERS} -c work_mem=${POSTGRES_WORK_MEM} -c listen_addresses='*'
+    restart: ${RESTART_POLICY:-always}
+    environment:
+      - POSTGRES_USER
+      - POSTGRES_PASSWORD
+      - PGAUTO_REINDEX=no
+    shm_size: ${POSTGRES_SHM_SIZE}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      interval: 1s
+      timeout: 5s
+      retries: 25
     ports:
       - "${POSTGRES_EXPOSE:-127.0.0.1:5432}:5432"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-# This compose file is imported by PO for tests so intentionally has no volume or network definitions
+# This compose file is imported by PO for tests so intentionally has no volume or network definitions.
+# It also excludes the PostgreSQL service (for now)
 services:
   redis:
     image: redis:7.2-alpine
@@ -9,18 +10,3 @@ services:
     image: mongo:4.4
     restart: ${RESTART_POLICY:-always}
     command: mongod --wiredTigerCacheSizeGB ${MONGODB_CACHE_SIZE}
-
-  postgresql:
-    image: ${POSTGRES_IMAGE}
-    command: postgres -c shared_buffers=${POSTGRES_SHARED_BUFFERS:-128MB} -c work_mem=${POSTGRES_WORK_MEM:-4MB} -c listen_addresses='*'
-    restart: ${RESTART_POLICY:-always}
-    environment:
-      - POSTGRES_USER
-      - POSTGRES_PASSWORD
-      - PGAUTO_REINDEX=no
-    shm_size: ${POSTGRES_SHM_SIZE:-256m}
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
-      interval: 1s
-      timeout: 5s
-      retries: 25

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,13 +12,13 @@ services:
 
   postgresql:
     image: ${POSTGRES_IMAGE}
-    command: postgres -c shared_buffers=${POSTGRES_SHARED_BUFFERS} -c work_mem=${POSTGRES_WORK_MEM} -c listen_addresses='*'
+    command: postgres -c shared_buffers=${POSTGRES_SHARED_BUFFERS:-128MB} -c work_mem=${POSTGRES_WORK_MEM:-4MB} -c listen_addresses='*'
     restart: ${RESTART_POLICY:-always}
     environment:
       - POSTGRES_USER
       - POSTGRES_PASSWORD
       - PGAUTO_REINDEX=no
-    shm_size: ${POSTGRES_SHM_SIZE}
+    shm_size: ${POSTGRES_SHM_SIZE:-256m}
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
       interval: 1s


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What
- PO intergration tests reference the docker-compose file but were not setting the nexessary environment variables

