### PR TITLE
fix: Explicitly set POSTGRES_EXPOSE

### DIFF
--- a/.env
+++ b/.env
@@ -14,7 +14,7 @@ POSTGRES_SHARED_BUFFERS=128MB
 POSTGRES_WORK_MEM=4MB
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=SuperSecret123!
-POSTGRES_EXPOSE=5432
+POSTGRES_EXPOSE=127.0.0.1:5432
 
 # The "bootstrap" user has minimal permissions to create other users, so is less secret
 PG_BOOTSTRAP_USERNAME=bootstrap


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What
Explicitly set POSTGRES_EXPOSE as otherwise use value from upstream project when called via run.
This is currently an issue with off-query as it uses its own PostgreSQL database at the moment. Won't be an issue once off-query is migrated to use the shared database

