### PR TITLE
chore: Fix project name in staging

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -83,15 +83,12 @@ jobs:
 
           echo "RESTART_POLICY=always" >> .env
 
-          # Use old po project name for now so we don't disrupt the current deployment
-          echo "COMPOSE_PROJECT_NAME=po" >> .env
+          echo "COMPOSE_PROJECT_NAME=off_shared" >> .env
           echo "COMMON_NET_NAME=${{ env.COMMON_NET_NAME }}" >> .env
 
           echo "COMPOSE_PATH_SEPARATOR=;" >> .env
           echo "COMPOSE_FILE=docker-compose.yml;docker/${{ matrix.env }}.yml" >> .env
 
-          # Use dbdata docker volume for now to keep consistency with previous po owned deployment
-          echo "MONGODB_DATA_VOLUME=dbdata" >> .env
           # Set App variables
           echo "MONGODB_CACHE_SIZE=${{ env.MONGODB_CACHE_SIZE }}" >> .env
           echo "MONGODB_HOST=${{ env.MONGODB_HOST }}" >> .env
@@ -137,7 +134,15 @@ jobs:
         command_timeout: 15m
         script: |
           cd ${{ matrix.env }}
-          make run
+
+          # Note this is temporary code to stop the old po containers while the project is being renamed
+          # It can be removed once staging has been upgraded
+          docker rm -f po-mongodb_exporter-1 || echo "Old container already stopped. Can remove this code"
+          docker rm -f po-mongodb-1 || echo "Old container already stopped. Can remove this code"
+          docker rm -f po-redis-1 || echo "Old container already stopped. Can remove this code"
+          # End of temporary code
+
+          make up
 
     - name: Check services are up
       uses: appleboy/ssh-action@master

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,13 @@ include .env
 
 export
 
-run: create_external_networks
+up: create_external_networks
 # Make sure the import directory is owned by the host, not docker
 	@mkdir -p ./import
 	docker compose up --wait
+
+# We have no dependencies and no locally build images so run == up
+run: up
 
 stop: 
 	docker compose stop

--- a/docker/shared-net.yml
+++ b/docker/shared-net.yml
@@ -11,7 +11,6 @@ services:
     ports:
       - 27017:27017
     volumes:
-      # Use dbdata docker volume for now to keep consistency with previous po owned deployment
       - dbdata:/data/db
       - ./import:/import
     networks:
@@ -36,11 +35,13 @@ services:
 volumes:
   redisdata:
     external: true
-    name: ${COMPOSE_PROJECT_NAME}_redisdata
+    # Use this docker volume name to keep consistency with previous po owned deployment
+    name: po_redisdata
 
   dbdata:
     external: true
-    name: ${MONGODB_DATA_VOLUME}
+    # Use this docker volume name to keep consistency with previous po owned deployment
+    name: dbdata
 
   pg_data:
     external: true


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What
When shared services were first introduced they were deployed in staging under the "po" project name to minimise disruption.

This is now causing some confusion, so this PR moves all containers to the off_shared project namespace
