### PR TITLE
feat!: Temporarily remove OpenTelemetry support

### DIFF
--- a/docker-compose-run.yml
+++ b/docker-compose-run.yml
@@ -55,20 +55,6 @@ services:
       - all
       - postgresql
 
-  # Note this is only used for local development. In production,
-  # central monitoring platform is used to collect metrics
-  # and traces: https://github.com/openfoodfacts/openfoodfacts-monitoring
-  otel-collector:
-    image: docker.io/grafana/otel-lgtm:latest
-    environment:
-      - GF_PATHS_DATA=/data/grafana
-    ports:
-      - 127.0.0.1:3000:3000
-      - 127.0.0.1:4317:4317
-      - 127.0.0.1:4318:4318
-    networks:
-      - common_net
-
 volumes:
   dbdata:
   redisdata:


### PR DESCRIPTION
### What
- This reverts commit 8ca67ad106f7379cd9c415c2d6f125b63c201f1c.
- Temporarily, until we figure out a better OTEL option for local dev without always starting a slow container
- To avoid conflicts with Grafana in the current deployment

### Fixes bug(s)
- https://github.com/openfoodfacts/openfoodfacts-shared-services/pull/5#issuecomment-4141979951

